### PR TITLE
fix(README): update link to Gitpod for main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This project is part of the lecture *Web Engineering 2* and is a clone of the popular card game *Cards against Humanity*.
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/yannickkirschen/cards-against-dhbw/tree/gitpod)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/yannickkirschen/cards-against-dhbw/)
 
 ## Developers
 


### PR DESCRIPTION
The "open in Gitpod" link tried to open a workspace based on the branch `Gitpod`which doesn't exist anymore.